### PR TITLE
Reset version.json baseline after Option B validation test

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1.0",
+  "version": "2.0.8",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/hotfix$",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1.1-alpha",
+  "version": "2.1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/hotfix$",


### PR DESCRIPTION
Reverts the two version.json bumps from validating the app token approach. Releasing cleanly as v2.1.0 next.