### PR TITLE
Remove stale develop status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,4 @@ public class PeopleHaveFullNames : Migration // #2 inherit from Migration
 
 | Branch     | Action                                                                                                                                                                                                                      |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `develop`  | [![Build status](https://github.com/Stillpoint-Software/hyperbee.migrations/actions/workflows/pack_publish.yml/badge.svg?branch=develop)](https://github.com/Stillpoint-Software/hyperbee.migration/actions/workflows/pack_publish.yml)  |
 | `main`     | [![Build status](https://github.com/Stillpoint-Software/hyperbee.migrations/actions/workflows/pack_publish.yml/badge.svg)](https://github.com/Stillpoint-Software/hyperbee.migration/actions/workflows/pack_publish.yml)                 |


### PR DESCRIPTION
Follow-up to trunk-based migration — the develop branch is gone, the badge row should be too.