### PR TITLE
Disable Liquid in local-jekyll.md to fix Pages build

### DIFF
--- a/docs/site/local-jekyll.md
+++ b/docs/site/local-jekyll.md
@@ -1,3 +1,6 @@
+---
+render_with_liquid: false
+---
 # Running Jekyll Docs Locally (Docker)
 
 Reusable recipe for previewing `just-the-docs` / GitHub Pages sites locally


### PR DESCRIPTION
Fixes 'Invalid syntax for include tag' from Liquid trying to parse code-block examples.