### PR TITLE
Integration-test hardening + bootstrap race tolerance + XML docs

### DIFF
--- a/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Bootstrap/Steps/LedgerIndexInitStep.cs
+++ b/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Bootstrap/Steps/LedgerIndexInitStep.cs
@@ -84,14 +84,35 @@ public sealed class LedgerIndexInitStep : IBootstrapStep
 
             logger.LogInformation( "{step} creating ledger index `{idx}` with strict mapping", Name, indexName );
 
-            var createResponse = await context.Client.LowLevel.Indices.CreateAsync<StringResponse>(
-                indexName,
-                PostData.String( DefaultMappingJson ),
-                ctx: context.CancellationToken
-            ).ConfigureAwait( false );
+            StringResponse createResponse;
+            try
+            {
+                createResponse = await context.Client.LowLevel.Indices.CreateAsync<StringResponse>(
+                    indexName,
+                    PostData.String( DefaultMappingJson ),
+                    ctx: context.CancellationToken
+                ).ConfigureAwait( false );
+            }
+            catch ( OpenSearchClientException ex ) when ( IsResourceAlreadyExists( ex.Response ) )
+            {
+                // TOCTOU race: another runner created the index between our Exists()
+                // check and Create(). Verify the mapping and treat as success.
+                logger.LogDebug( "{step} ledger index `{idx}` created concurrently by another runner; verifying mapping", Name, indexName );
+                var verifyDetail = await VerifyMappingAsync( context, indexName, logger ).ConfigureAwait( false );
+                var raceElapsed = context.TimeProvider.GetElapsedTime( start );
+                return StepOutcome.Succeeded( Name, raceElapsed, $"{verifyDetail} (raced)" );
+            }
 
             if ( !createResponse.Success )
             {
+                if ( IsResourceAlreadyExists( createResponse ) )
+                {
+                    logger.LogDebug( "{step} ledger index `{idx}` created concurrently by another runner; verifying mapping", Name, indexName );
+                    var verifyDetail = await VerifyMappingAsync( context, indexName, logger ).ConfigureAwait( false );
+                    var raceElapsed = context.TimeProvider.GetElapsedTime( start );
+                    return StepOutcome.Succeeded( Name, raceElapsed, $"{verifyDetail} (raced)" );
+                }
+
                 var detail = createResponse.OriginalException?.Message ?? createResponse.Body ?? "Unknown create failure";
                 var ex = new OpenSearchProviderException(
                     $"{Name} could not create ledger index `{indexName}`. {detail}",
@@ -154,5 +175,30 @@ public sealed class LedgerIndexInitStep : IBootstrapStep
 
         logger.LogDebug( "{step} ledger schema verified ({count} required fields present)", "ledger-init", RequiredFields.Length );
         return "verified existing schema";
+    }
+
+    // Detects the OpenSearch-specific 400 body that signals a TOCTOU race
+    // between Exists() and Create() — another runner won. Inspect the body
+    // string rather than the status code alone because OS reuses 400 for
+    // genuine bad-request shapes (malformed mapping, invalid settings).
+    private static bool IsResourceAlreadyExists( IApiCallDetails? response )
+    {
+        if ( response is null || response.HttpStatusCode != 400 )
+            return false;
+
+        var body = response.ResponseBodyInBytes is { Length: > 0 } bytes
+            ? System.Text.Encoding.UTF8.GetString( bytes )
+            : null;
+
+        return body is not null && body.Contains( "resource_already_exists_exception", StringComparison.Ordinal );
+    }
+
+    private static bool IsResourceAlreadyExists( StringResponse response )
+    {
+        if ( response.HttpStatusCode != 400 )
+            return false;
+
+        return !string.IsNullOrEmpty( response.Body )
+            && response.Body.Contains( "resource_already_exists_exception", StringComparison.Ordinal );
     }
 }

--- a/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Bootstrap/Steps/LockIndexInitStep.cs
+++ b/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Bootstrap/Steps/LockIndexInitStep.cs
@@ -67,14 +67,33 @@ public sealed class LockIndexInitStep : IBootstrapStep
 
             logger.LogInformation( "{step} creating lock index `{idx}` (replicas=0)", Name, indexName );
 
-            var createResponse = await context.Client.LowLevel.Indices.CreateAsync<StringResponse>(
-                indexName,
-                PostData.String( DefaultMappingJson ),
-                ctx: context.CancellationToken
-            ).ConfigureAwait( false );
+            StringResponse createResponse;
+            try
+            {
+                createResponse = await context.Client.LowLevel.Indices.CreateAsync<StringResponse>(
+                    indexName,
+                    PostData.String( DefaultMappingJson ),
+                    ctx: context.CancellationToken
+                ).ConfigureAwait( false );
+            }
+            catch ( OpenSearchClientException ex ) when ( IsResourceAlreadyExists( ex.Response ) )
+            {
+                // TOCTOU race: another runner created the lock index between our
+                // Exists() check and Create(). Treat as success.
+                logger.LogDebug( "{step} lock index `{idx}` created concurrently by another runner", Name, indexName );
+                var raceElapsed = context.TimeProvider.GetElapsedTime( start );
+                return StepOutcome.Succeeded( Name, raceElapsed, "exists (raced)" );
+            }
 
             if ( !createResponse.Success )
             {
+                if ( IsResourceAlreadyExists( createResponse ) )
+                {
+                    logger.LogDebug( "{step} lock index `{idx}` created concurrently by another runner", Name, indexName );
+                    var raceElapsed = context.TimeProvider.GetElapsedTime( start );
+                    return StepOutcome.Succeeded( Name, raceElapsed, "exists (raced)" );
+                }
+
                 var detail = createResponse.OriginalException?.Message ?? createResponse.Body ?? "Unknown create failure";
                 var ex = new OpenSearchProviderException(
                     $"{Name} could not create lock index `{indexName}`. {detail}",
@@ -96,5 +115,30 @@ public sealed class LockIndexInitStep : IBootstrapStep
             return StepOutcome.Failed( Name, elapsed, new OpenSearchProviderException(
                 $"{Name} threw an unexpected exception. {ex.Message}", ex ) );
         }
+    }
+
+    // Detects the OpenSearch-specific 400 body that signals a TOCTOU race
+    // between Exists() and Create() — another runner won. Inspect the body
+    // string rather than the status code alone because OS reuses 400 for
+    // genuine bad-request shapes (malformed mapping, invalid settings).
+    private static bool IsResourceAlreadyExists( IApiCallDetails? response )
+    {
+        if ( response is null || response.HttpStatusCode != 400 )
+            return false;
+
+        var body = response.ResponseBodyInBytes is { Length: > 0 } bytes
+            ? System.Text.Encoding.UTF8.GetString( bytes )
+            : null;
+
+        return body is not null && body.Contains( "resource_already_exists_exception", StringComparison.Ordinal );
+    }
+
+    private static bool IsResourceAlreadyExists( StringResponse response )
+    {
+        if ( response.HttpStatusCode != 400 )
+            return false;
+
+        return !string.IsNullOrEmpty( response.Body )
+            && response.Body.Contains( "resource_already_exists_exception", StringComparison.Ordinal );
     }
 }

--- a/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Dispatch/StatementDispatcher.cs
+++ b/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Dispatch/StatementDispatcher.cs
@@ -6,6 +6,8 @@ using Hyperbee.Migrations.Providers.OpenSearch.Internal.Bootstrap.Steps;
 using Hyperbee.Migrations.Providers.OpenSearch.Internal.Middleware;
 using Microsoft.Extensions.Logging;
 using OpenSearch.Net;
+using HttpMethod = OpenSearch.Net.HttpMethod;
+using Osc = OpenSearch.Client;
 
 namespace Hyperbee.Migrations.Providers.OpenSearch.Internal.Dispatch;
 
@@ -140,7 +142,7 @@ public sealed class StatementDispatcher
     {
         var ll = context.Client.LowLevel;
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.GET, string.Empty, context.CancellationToken ).ConfigureAwait( false );
+            HttpMethod.GET, string.Empty, context.CancellationToken ).ConfigureAwait( false );
 
         if ( !response.Success )
         {
@@ -433,8 +435,19 @@ public sealed class StatementDispatcher
                 OpenSearchResponseStatus: 200 );
         }
 
-        var dynamicResponse = await ll.Indices.UpdateSettingsAsync<StringResponse>(
-            ast.IndexName, PostData.String( body ), ctx: context.CancellationToken ).ConfigureAwait( false );
+        StringResponse dynamicResponse;
+        try
+        {
+            dynamicResponse = await ll.Indices.UpdateSettingsAsync<StringResponse>(
+                ast.IndexName, PostData.String( body ), ctx: context.CancellationToken ).ConfigureAwait( false );
+        }
+        catch ( OpenSearchClientException ex )
+        {
+            return new StatementResult( StatementOutcome.Failed, verb,
+                Detail: ex.Message,
+                OpenSearchResponseStatus: ex.Response?.HttpStatusCode,
+                Exception: ex );
+        }
 
         var result = BuildResult( verb, dynamicResponse, $"settings updated on `{ast.IndexName}`" );
 
@@ -464,8 +477,8 @@ public sealed class StatementDispatcher
         var verb = ast.Verb;
 
         var threshold = ast.Threshold == HealthStatus.Green
-            ? global::OpenSearch.Net.WaitForStatus.Green
-            : global::OpenSearch.Net.WaitForStatus.Yellow;
+            ? WaitForStatus.Green
+            : WaitForStatus.Yellow;
 
         var timeout = ast.Timeout ?? context.Options.ImplicitWaitTimeout;
 
@@ -474,7 +487,7 @@ public sealed class StatementDispatcher
             {
                 var sel = s.WaitForStatus( threshold ).Timeout( timeout );
                 if ( ast.IndexName is not null )
-                    sel = sel.Index( global::OpenSearch.Client.Indices.Index( ast.IndexName ) );
+                    sel = sel.Index( Osc.Indices.Index( ast.IndexName ) );
                 return sel;
             },
             ct: context.CancellationToken
@@ -577,8 +590,19 @@ public sealed class StatementDispatcher
         // is a Phase 2 enhancement (R-11) — authors who need it can compose with
         // WAIT UNTIL TASK once the runner exposes the task id.
 
-        var response = await ll.ReindexOnServerAsync<StringResponse>(
-            PostData.String( body ), ctx: context.CancellationToken ).ConfigureAwait( false );
+        StringResponse response;
+        try
+        {
+            response = await ll.ReindexOnServerAsync<StringResponse>(
+                PostData.String( body ), ctx: context.CancellationToken ).ConfigureAwait( false );
+        }
+        catch ( OpenSearchClientException ex )
+        {
+            return new StatementResult( StatementOutcome.Failed, verb,
+                Detail: ex.Message,
+                OpenSearchResponseStatus: ex.Response?.HttpStatusCode,
+                Exception: ex );
+        }
 
         var result = BuildResult( verb, response, $"reindex {ast.Source} -> {ast.Destination}" );
 
@@ -613,7 +637,7 @@ public sealed class StatementDispatcher
             """;
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.POST,
+            HttpMethod.POST,
             "_aliases",
             context.CancellationToken,
             data: PostData.String( body ) ).ConfigureAwait( false );
@@ -638,7 +662,7 @@ public sealed class StatementDispatcher
             """;
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.POST,
+            HttpMethod.POST,
             "_aliases",
             context.CancellationToken,
             data: PostData.String( body ) ).ConfigureAwait( false );
@@ -658,7 +682,7 @@ public sealed class StatementDispatcher
             """;
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.POST,
+            HttpMethod.POST,
             "_aliases",
             context.CancellationToken,
             data: PostData.String( body ) ).ConfigureAwait( false );
@@ -686,7 +710,7 @@ public sealed class StatementDispatcher
         // Idempotent: PUT replaces an existing template definition.
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.PUT,
+            HttpMethod.PUT,
             $"_index_template/{ast.TemplateName}",
             context.CancellationToken,
             data: PostData.String( body ) ).ConfigureAwait( false );
@@ -714,7 +738,7 @@ public sealed class StatementDispatcher
         // by composable index templates via `composed_of`.
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.PUT,
+            HttpMethod.PUT,
             $"_component_template/{ast.ComponentName}",
             context.CancellationToken,
             data: PostData.String( body ) ).ConfigureAwait( false );
@@ -732,7 +756,7 @@ public sealed class StatementDispatcher
         if ( ast.IfExists )
         {
             var existsResponse = await ll.DoRequestAsync<StringResponse>(
-                global::OpenSearch.Net.HttpMethod.HEAD,
+                HttpMethod.HEAD,
                 $"_index_template/{ast.TemplateName}",
                 context.CancellationToken ).ConfigureAwait( false );
 
@@ -746,7 +770,7 @@ public sealed class StatementDispatcher
         }
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.DELETE,
+            HttpMethod.DELETE,
             $"_index_template/{ast.TemplateName}",
             context.CancellationToken ).ConfigureAwait( false );
 
@@ -763,7 +787,7 @@ public sealed class StatementDispatcher
         if ( ast.IfExists )
         {
             var existsResponse = await ll.DoRequestAsync<StringResponse>(
-                global::OpenSearch.Net.HttpMethod.HEAD,
+                HttpMethod.HEAD,
                 $"_component_template/{ast.ComponentName}",
                 context.CancellationToken ).ConfigureAwait( false );
 
@@ -781,7 +805,7 @@ public sealed class StatementDispatcher
         // dispatcher surfaces that error verbatim via BuildResult.
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.DELETE,
+            HttpMethod.DELETE,
             $"_component_template/{ast.ComponentName}",
             context.CancellationToken ).ConfigureAwait( false );
 
@@ -819,21 +843,35 @@ public sealed class StatementDispatcher
         // not under _source — unusual but documented), retry PUT with the
         // CAS query parameters. Mirrors LockHandle.RenewLockAsync's
         // optimistic-concurrency pattern.
+        //
+        // 409 surfaces either as a non-Success StringResponse (default
+        // settings) OR as OpenSearchClientException (when the consumer
+        // configured ConnectionSettings.ThrowExceptions(), which test
+        // containers and some prod deployments do). Handle both uniformly,
+        // matching the pattern in OpenSearchRecordStore.AcquireLockAsync.
 
-        var firstResponse = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.PUT,
-            policyPath,
-            context.CancellationToken,
-            data: PostData.String( body ) ).ConfigureAwait( false );
+        var (firstResponse, firstHit409) = await PutPolicyAsync(
+            ll, policyPath, body, context.CancellationToken ).ConfigureAwait( false );
 
-        if ( firstResponse.HttpStatusCode != 409 )
-            return BuildResult( verb, firstResponse, $"policy `{ast.PolicyId}` created/updated" );
+        if ( !firstHit409 )
+            return BuildResult( verb, firstResponse!, $"policy `{ast.PolicyId}` created/updated" );
 
         // 409 — read the current version to retry with CAS.
-        var getResponse = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.GET,
-            policyPath,
-            context.CancellationToken ).ConfigureAwait( false );
+        StringResponse? getResponse;
+        try
+        {
+            getResponse = await ll.DoRequestAsync<StringResponse>(
+                HttpMethod.GET,
+                policyPath,
+                context.CancellationToken ).ConfigureAwait( false );
+        }
+        catch ( OpenSearchClientException ex )
+        {
+            return new StatementResult( StatementOutcome.Failed, verb,
+                Detail: $"policy `{ast.PolicyId}` returned 409 on PUT but the follow-up GET to read _seq_no/_primary_term for CAS retry threw: HTTP {ex.Response?.HttpStatusCode}, {ex.Message}",
+                OpenSearchResponseStatus: ex.Response?.HttpStatusCode,
+                Exception: ex );
+        }
 
         if ( !getResponse.Success || getResponse.Body is null )
         {
@@ -866,28 +904,63 @@ public sealed class StatementDispatcher
                 Exception: ex );
         }
 
-        // Retry the PUT with CAS query params. Inline rather than via a typed
-        // IRequestParameters because there's no ISM-specific request-parameters
-        // type in OpenSearch.Net (the endpoint is plugin-served).
-        var retryPath = $"{policyPath}?if_seq_no={seqNo}&if_primary_term={primaryTerm}";
-        var retryResponse = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.PUT,
-            retryPath,
-            context.CancellationToken,
-            data: PostData.String( body ) ).ConfigureAwait( false );
+        // Retry the PUT with CAS query params passed via IRequestParameters —
+        // OpenSearch.Net rejects paths that embed query strings directly.
+        var (retryResponse, retryHit409) = await PutPolicyAsync(
+            ll, policyPath, body, context.CancellationToken,
+            new CasPutParameters( seqNo, primaryTerm ) ).ConfigureAwait( false );
 
-        if ( retryResponse.HttpStatusCode == 409 )
+        if ( retryHit409 )
         {
             // Second 409 means another writer beat us between the GET and
             // the retry PUT. The lock should make this rare; treat as hard
             // failure rather than recursing.
             return new StatementResult( StatementOutcome.Failed, verb,
                 Detail: $"policy `{ast.PolicyId}` CAS retry hit a second 409 — concurrent writer between GET (_seq_no={seqNo}, _primary_term={primaryTerm}) and retry PUT.",
-                OpenSearchResponseStatus: retryResponse.HttpStatusCode,
-                Exception: retryResponse.OriginalException ?? new InvalidOperationException( $"concurrent writer on policy {ast.PolicyId}" ) );
+                OpenSearchResponseStatus: 409,
+                Exception: retryResponse?.OriginalException ?? new InvalidOperationException( $"concurrent writer on policy {ast.PolicyId}" ) );
         }
 
-        return BuildResult( verb, retryResponse, $"policy `{ast.PolicyId}` updated via CAS retry (seq={seqNo}, term={primaryTerm})" );
+        return BuildResult( verb, retryResponse!, $"policy `{ast.PolicyId}` updated via CAS retry (seq={seqNo}, term={primaryTerm})" );
+    }
+
+    // PUT a policy body and report whether the result was a 409, transparent
+    // to whether the consumer's ConnectionSettings has ThrowExceptions enabled.
+    // Returns (response, hit409). When hit409 is true, response may be null
+    // (the throwing path).
+    private static async Task<(StringResponse? Response, bool Hit409)> PutPolicyAsync(
+        IOpenSearchLowLevelClient ll,
+        string path,
+        string body,
+        CancellationToken cancellationToken,
+        IRequestParameters? requestParameters = null )
+    {
+        try
+        {
+            var response = await ll.DoRequestAsync<StringResponse>(
+                HttpMethod.PUT,
+                path,
+                cancellationToken,
+                data: PostData.String( body ),
+                requestParameters: requestParameters ).ConfigureAwait( false );
+            return (response, response.HttpStatusCode == 409);
+        }
+        catch ( OpenSearchClientException ex ) when ( ex.Response?.HttpStatusCode == 409 )
+        {
+            return (null, true);
+        }
+    }
+
+    private sealed class CasPutParameters : RequestParameters<CasPutParameters>
+    {
+        public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
+        public override bool SupportsBody => true;
+
+        public CasPutParameters( long seqNo, long primaryTerm )
+        {
+            QueryString["if_seq_no"] = seqNo;
+            QueryString["if_primary_term"] = primaryTerm;
+        }
     }
 
     // --- APPLY POLICY <id> TO <pattern> ---
@@ -912,7 +985,7 @@ public sealed class StatementDispatcher
             """;
 
         var response = await ll.DoRequestAsync<StringResponse>(
-            global::OpenSearch.Net.HttpMethod.POST,
+            HttpMethod.POST,
             $"{IsmPathPrefix}/add/{ast.IndexPattern}",
             context.CancellationToken,
             data: PostData.String( body ) ).ConfigureAwait( false );
@@ -1052,8 +1125,8 @@ public sealed class StatementDispatcher
     private static async Task ExecuteHealthWaitAsync( StatementContext context, IReadOnlyCollection<string> indices )
     {
         var threshold = context.Options.ClusterHealthThreshold == ClusterHealthThreshold.Green
-            ? global::OpenSearch.Net.WaitForStatus.Green
-            : global::OpenSearch.Net.WaitForStatus.Yellow;
+            ? WaitForStatus.Green
+            : WaitForStatus.Yellow;
 
         var timeout = context.Options.ImplicitWaitTimeout;
 
@@ -1063,7 +1136,7 @@ public sealed class StatementDispatcher
                 selector: s => s
                     .WaitForStatus( threshold )
                     .Timeout( timeout )
-                    .Index( global::OpenSearch.Client.Indices.Index( string.Join( ",", indices ) ) ),
+                    .Index( Osc.Indices.Index( string.Join( ",", indices ) ) ),
                 ct: context.CancellationToken
             ).ConfigureAwait( false );
         }

--- a/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Middleware/SafeDefaultMergeMiddleware.cs
+++ b/src/Hyperbee.Migrations.Providers.OpenSearch/Internal/Middleware/SafeDefaultMergeMiddleware.cs
@@ -77,13 +77,18 @@ public sealed class SafeDefaultMergeMiddleware
     //   1. If InjectOpTypeCreate is false (UNSAFE branch): pass body through
     //      unchanged. Author owns idempotency.
     //   2. If body is null: produce
-    //        { "source": { "index": <src> }, "dest": { "index": <dst>, "op_type": "create" } }
-    //   3. If body has dest object missing op_type: merge `op_type: create`
-    //   4. If body has dest with `op_type: create` already: pass through
+    //        { "source": { "index": <src> }, "dest": { "index": <dst>, "op_type": "create" }, "conflicts": "proceed" }
+    //   3. If body has dest object missing op_type: merge `op_type: create` and `conflicts: proceed`
+    //      (unless body already sets `conflicts`)
+    //   4. If body has dest with `op_type: create` already: merge `conflicts: proceed`
     //      (idempotent inject)
     //   5. If body has dest with conflicting op_type (e.g., "index"): throw
     //      SafeDefaultConflictException — author must use REINDEX UNSAFE("...")
     //      to opt out
+    //
+    // `conflicts: proceed` is co-injected with `op_type: create` because the safe-default
+    // semantics are "skip pre-existing docs" — aborting on the first conflict (the
+    // OpenSearch default) would return HTTP 409 and defeat idempotency entirely.
     //
     // The middleware also ensures source.index and dest.index match the AST's
     // Source/Destination unless the body explicitly overrides them (advanced use).
@@ -107,12 +112,18 @@ public sealed class SafeDefaultMergeMiddleware
         if ( !dest.TryGetPropertyValue( "op_type", out var existing ) || existing is null )
         {
             dest["op_type"] = "create";
+            if ( !clone.ContainsKey( "conflicts" ) )
+                clone["conflicts"] = "proceed";
             return clone;
         }
 
         var existingValue = existing.GetValue<string>();
         if ( existingValue == "create" )
+        {
+            if ( !clone.ContainsKey( "conflicts" ) )
+                clone["conflicts"] = "proceed";
             return clone; // idempotent inject
+        }
 
         throw new SafeDefaultConflictException(
             $"REINDEX body specifies `op_type: \"{existingValue}\"` which conflicts with the safe-default `op_type: create`. " +

--- a/src/Hyperbee.Migrations.Providers.OpenSearch/OpenSearchExceptions.cs
+++ b/src/Hyperbee.Migrations.Providers.OpenSearch/OpenSearchExceptions.cs
@@ -1,44 +1,79 @@
-﻿#nullable enable
+#nullable enable
 namespace Hyperbee.Migrations.Providers.OpenSearch;
 
 // Provider-specific exception hierarchy. Typed exceptions allow callers to
 // pattern-match on classes of failure without parsing log strings.
 
+/// <summary>
+/// Base type for all OpenSearch-provider exceptions. Catch this to handle any
+/// provider-originated failure without coupling to a specific subclass.
+/// </summary>
 public class OpenSearchProviderException : Exception
 {
+    /// <summary>Initializes a new instance with a descriptive message.</summary>
     public OpenSearchProviderException( string message ) : base( message ) { }
+
+    /// <summary>Initializes a new instance with a descriptive message and the underlying cause.</summary>
     public OpenSearchProviderException( string message, Exception inner ) : base( message, inner ) { }
 }
 
+/// <summary>
+/// Bootstrap could not bring the cluster to a usable state — the ledger or lock
+/// index could not be created/verified, the cluster did not reach the configured
+/// health threshold, or a required step failed.
+/// </summary>
 public sealed class OpenSearchNotReadyException : OpenSearchProviderException
 {
+    /// <summary>Initializes a new instance with a descriptive message.</summary>
     public OpenSearchNotReadyException( string message ) : base( message ) { }
+
+    /// <summary>Initializes a new instance with a descriptive message and the underlying cause.</summary>
     public OpenSearchNotReadyException( string message, Exception inner ) : base( message, inner ) { }
 }
 
+/// <summary>
+/// Ledger index exists but its mapping is missing one of the required forensic
+/// fields (R-06). The ledger schema is immutable; recreate the index to recover.
+/// </summary>
 public sealed class OpenSearchLedgerSchemaMismatchException : OpenSearchProviderException
 {
+    /// <summary>Initializes a new instance with a descriptive message.</summary>
     public OpenSearchLedgerSchemaMismatchException( string message ) : base( message ) { }
 }
 
+/// <summary>
+/// Migration lock exceeded <see cref="OpenSearchMigrationOptions.LockMaxLifetime"/>.
+/// The in-flight migration's <see cref="System.Threading.CancellationToken"/> has
+/// been signaled; the runner is winding down.
+/// </summary>
 public sealed class MigrationLockExpiredException : OpenSearchProviderException
 {
+    /// <summary>Initializes a new instance with a descriptive message.</summary>
     public MigrationLockExpiredException( string message ) : base( message ) { }
 }
 
+/// <summary>
+/// AWS SigV4 authentication was requested via
+/// <see cref="OpenSearchAuthenticationOptions"/> but the required configuration
+/// (region, credentials, service) was not supplied.
+/// </summary>
 public sealed class AwsSigV4NotConfiguredException : OpenSearchProviderException
 {
+    /// <summary>Initializes a new instance with a descriptive message.</summary>
     public AwsSigV4NotConfiguredException( string message ) : base( message ) { }
 }
 
-// R-19: thrown by RollbackStatementsFromAsync when a statement entry has no
-// `rollback` field. The author's intent is "this operation is irreversible";
-// the runner refuses Down rather than guess at an inverse.
-
+/// <summary>
+/// R-19: thrown by Down execution when a statement has no <c>rollback</c> field.
+/// The author's intent is "this operation is irreversible"; the runner refuses
+/// to guess at an inverse rather than risk corruption.
+/// </summary>
 public sealed class RollbackNotSupportedException : OpenSearchProviderException
 {
+    /// <summary>Index of the statement (within the migration's statement list) that lacks a rollback definition.</summary>
     public int StatementIndex { get; }
 
+    /// <summary>Initializes a new instance for the statement at <paramref name="statementIndex"/>.</summary>
     public RollbackNotSupportedException( int statementIndex, string message )
         : base( message )
     {
@@ -46,30 +81,40 @@ public sealed class RollbackNotSupportedException : OpenSearchProviderException
     }
 }
 
-// R-15: thrown at the resource-runner entry point when a statements.json
-// file declares a `context:` block AND the runner is configured with
-// ContextResolutionPolicy.RequireExplicit AND ActiveContext is null/empty.
-// `RequireExplicit` is the production default (set by WithProductionDefaults
-// per R-29); silent prod-everywhere behavior is forbidden by the trust
-// boundary, so the runner must fail loud rather than guess.
-
+/// <summary>
+/// R-15: thrown at the resource-runner entry point when a <c>statements.json</c>
+/// declares a <c>context:</c> block, <see cref="ContextResolutionPolicy.RequireExplicit"/>
+/// is in effect, and <see cref="OpenSearchMigrationOptions.ActiveContext"/> is unset.
+/// </summary>
+/// <remarks>
+/// <see cref="ContextResolutionPolicy.RequireExplicit"/> is the production default
+/// (per R-29's <c>WithProductionDefaults</c>); silent prod-everywhere behavior is
+/// forbidden by the trust boundary, so the runner fails loud rather than guess.
+/// </remarks>
 public sealed class MissingActiveContextException : OpenSearchProviderException
 {
+    /// <summary>Initializes a new instance with a descriptive message.</summary>
     public MissingActiveContextException( string message )
         : base( message ) { }
 }
 
-// R-19: thrown when a migration's ledger record is in `partially_rolled_back`
-// state and the operator has not opted into recovery via OpenSearchMigrationOptions.ForceResume.
-// Subsequent runs are refused in either direction until the operator
-// inspects the cluster, reconciles state, and explicitly re-runs with
-// ForceResume = true (or deletes the record manually for a fresh Up).
-
+/// <summary>
+/// R-19: thrown when a migration's ledger record is in <c>partially_rolled_back</c>
+/// state and the operator has not opted into recovery via
+/// <see cref="OpenSearchMigrationOptions.ForceResume"/>. Subsequent runs are refused
+/// in either direction until the operator inspects the cluster, reconciles state,
+/// and explicitly re-runs with <c>ForceResume = true</c> (or deletes the record
+/// manually for a fresh Up).
+/// </summary>
 public sealed class OpenSearchPartialRollbackException : OpenSearchProviderException
 {
+    /// <summary>Identifier of the migration record stuck in <c>partially_rolled_back</c> state.</summary>
     public string RecordId { get; }
+
+    /// <summary>Index of the statement (within the migration's rollback sequence) that failed, if known.</summary>
     public int? FailedStatementIndex { get; }
 
+    /// <summary>Initializes a new instance describing the stuck record and (optionally) the failing statement index.</summary>
     public OpenSearchPartialRollbackException( string recordId, int? failedStatementIndex, string message )
         : base( message )
     {

--- a/src/Hyperbee.Migrations.Providers.OpenSearch/OpenSearchMigrationOptions.cs
+++ b/src/Hyperbee.Migrations.Providers.OpenSearch/OpenSearchMigrationOptions.cs
@@ -1,75 +1,145 @@
-﻿namespace Hyperbee.Migrations.Providers.OpenSearch;
+namespace Hyperbee.Migrations.Providers.OpenSearch;
 
+/// <summary>
+/// Cluster-health gate threshold the runner waits for before executing migrations.
+/// </summary>
 public enum ClusterHealthThreshold
 {
+    /// <summary>All primary shards active; some replicas may still be initializing.</summary>
     Yellow,
+    /// <summary>All primary and replica shards active.</summary>
     Green
 }
 
+/// <summary>
+/// Controls when the runner blocks on cluster wait-conditions (health, task
+/// completion) emitted by migration statements.
+/// </summary>
 public enum WaitMode
 {
+    /// <summary>Wait after every statement that emits a wait-condition. Safest; default.</summary>
     PerStatement,
+    /// <summary>Wait once at the end of each migration. Faster; assumes statements within a migration commute.</summary>
     PerMigration,
+    /// <summary>Never wait. Author owns synchronization; suitable for tests and fast-path scripts.</summary>
     Off
 }
 
+/// <summary>
+/// Behavior when a migration references <c>$context</c> but no
+/// <see cref="OpenSearchMigrationOptions.ActiveContext"/> is configured.
+/// </summary>
 public enum ContextResolutionPolicy
 {
+    /// <summary>Skip the migration silently when context is unset.</summary>
     SkipIfUnset,
+    /// <summary>Fail the run with a clear error when context is unset.</summary>
     RequireExplicit
 }
 
+/// <summary>
+/// OpenSearch-provider configuration for the migration runner. Controls ledger and
+/// lock-index naming, cluster wait behavior, lock heartbeat cadence, and runner-level
+/// safety knobs (UNSAFE justification, partial-rollback resume).
+/// </summary>
 public class OpenSearchMigrationOptions : MigrationOptions
 {
+    /// <summary>Default name for the migration ledger index.</summary>
     public const string DefaultLedgerIndex = ".migrations";
+
+    /// <summary>Default name for the migration lock index.</summary>
     public const string DefaultLockIndex = ".migrations-lock";
+
+    /// <summary>Default <c>_id</c> of the singleton lock document inside the lock index.</summary>
     public const string DefaultLockName = "migration_lock";
 
+    /// <summary>
+    /// Index storing applied-migration records. Created on first run with a strict
+    /// mapping; re-verified on subsequent runs.
+    /// </summary>
     public string LedgerIndex { get; set; } = DefaultLedgerIndex;
+
+    /// <summary>
+    /// Index storing the singleton lock document (<c>number_of_replicas: 0</c> per
+    /// PA-2 to eliminate replica-write coupling on the lock primary shard).
+    /// </summary>
     public string LockIndex { get; set; } = DefaultLockIndex;
+
+    /// <summary>
+    /// <c>_id</c> of the lock document inside <see cref="LockIndex"/>. Override to run
+    /// multiple independent migration scopes against the same cluster.
+    /// </summary>
     public string LockName { get; set; } = DefaultLockName;
 
+    /// <summary>Cluster-health threshold the runner waits for at startup and after schema-mutating statements.</summary>
     public ClusterHealthThreshold ClusterHealthThreshold { get; set; } = ClusterHealthThreshold.Yellow;
+
+    /// <summary>When the runner blocks on cluster wait-conditions; see <see cref="WaitMode"/>.</summary>
     public WaitMode WaitMode { get; set; } = WaitMode.PerStatement;
+
+    /// <summary>
+    /// When true, <c>UNSAFE</c>-modified statements must include a non-empty justification
+    /// string. Recommended for production; off by default to keep test scripts terse.
+    /// </summary>
     public bool RequireUnsafeJustification { get; set; } = false;
+
+    /// <summary>How the runner reacts when a migration references <c>$context</c> but <see cref="ActiveContext"/> is unset.</summary>
     public ContextResolutionPolicy ContextResolutionPolicy { get; set; } = ContextResolutionPolicy.SkipIfUnset;
 
+    /// <summary>
+    /// Active context label substituted for <c>$context</c> in migrations. Typically set
+    /// from environment (dev/staging/prod) so the same migration set targets the right cluster shape.
+    /// </summary>
     public string ActiveContext { get; set; }
+
+    /// <summary>
+    /// When true, the bootstrapper verifies the ledger and lock indices exist with the
+    /// required mapping but does not create them. Use in tightly-scoped IAM contexts
+    /// (e.g., AWS Managed) where the deploy role lacks <c>indices:admin/create</c>.
+    /// </summary>
     public bool AssumeIndicesExist { get; set; } = false;
 
-    // R-19: when a previous Down attempt halted partway through the rollback
-    // sequence, the ledger entry is `partially_rolled_back`. Subsequent runs
-    // are refused (loudly, with remediation) until the operator inspects the
-    // cluster, reconciles state, and opts in to a retry by setting this
-    // flag. The runner project (R-26) is expected to surface this as a
-    // `--force-resume` CLI flag once it lands.
-    //
-    // ForceResume = true bypasses the partially_rolled_back lockout; the
-    // runner proceeds as if the record were in a normal state. Use only
-    // after manual reconciliation — silently retrying a partially-failed
-    // rollback can leave the cluster in an indeterminate state.
+    /// <summary>
+    /// Bypass the partial-rollback lockout (R-19). When a previous Down attempt halted
+    /// partway through, subsequent runs are refused until the operator reconciles state
+    /// and opts in by setting this flag. Use only after manual reconciliation —
+    /// silently retrying a partially-failed rollback can leave the cluster in an
+    /// indeterminate state.
+    /// </summary>
     public bool ForceResume { get; set; } = false;
 
+    /// <summary>Timeout for implicit cluster waits emitted by migration statements (e.g., wait-for-status, wait-for-task).</summary>
     public TimeSpan ImplicitWaitTimeout { get; set; } = TimeSpan.FromSeconds( 30 );
 
-    // Heartbeat renewal interval. Must be shorter than LockStaleAfter so a healthy
-    // runner refreshes the lock before takeover candidates would consider it stale.
+    /// <summary>
+    /// Heartbeat renewal interval. Must be shorter than <see cref="LockStaleAfter"/>
+    /// so a healthy runner refreshes the lock before takeover candidates would
+    /// consider it stale.
+    /// </summary>
     public TimeSpan LockRenewInterval { get; set; } = TimeSpan.FromSeconds( 30 );
 
-    // After this duration without renewal, the lock is considered stale and another
-    // runner may take it over. Validation enforces LockStaleAfter >= 2 * LockRenewInterval
-    // and LockStaleAfter < LockMaxLifetime.
+    /// <summary>
+    /// After this duration without renewal, the lock is considered stale and another
+    /// runner may take it over. Validation enforces
+    /// <c>LockStaleAfter &gt;= 2 * LockRenewInterval</c> and
+    /// <c>LockStaleAfter &lt; LockMaxLifetime</c>.
+    /// </summary>
     public TimeSpan LockStaleAfter { get; set; } = TimeSpan.FromSeconds( 60 );
 
-    // Hard ceiling on total lock lifetime. When reached, in-flight migration is
-    // cancelled (CancellationToken signaled) and surfaces MigrationLockExpiredException.
+    /// <summary>
+    /// Hard ceiling on total lock lifetime. When reached, the in-flight migration is
+    /// cancelled (its <see cref="System.Threading.CancellationToken"/> is signaled) and
+    /// the runner surfaces <c>MigrationLockExpiredException</c>.
+    /// </summary>
     public TimeSpan LockMaxLifetime { get; set; } = TimeSpan.FromHours( 1 );
 
+    /// <summary>Initializes a new instance with no migration activator.</summary>
     public OpenSearchMigrationOptions()
         : this( null )
     {
     }
 
+    /// <summary>Initializes a new instance with the supplied <paramref name="migrationActivator"/>.</summary>
     public OpenSearchMigrationOptions( IMigrationActivator migrationActivator )
         : base( migrationActivator )
     {

--- a/tests/Hyperbee.Migrations.Integration.Tests/Container/Couchbase/CouchbaseTestContainer.cs
+++ b/tests/Hyperbee.Migrations.Integration.Tests/Container/Couchbase/CouchbaseTestContainer.cs
@@ -29,7 +29,13 @@ public class CouchbaseTestContainer
             .WithNetwork( network )
             .WithNetworkAliases( "db" )
 
-            .WithPortBinding( 80, 80 )
+            // Couchbase Server's documented ports are 8091-8096 (REST/UI/services)
+            // and 11210/11211 (data) — port 80 is not in the cluster-map and the
+            // SDK never connects to it, so binding host:80 was always vestigial.
+            // The previous binding ran into HTTP.sys URL-ACL conflicts on Windows
+            // hosts where Windows services (SSDP, WinRM, etc.) hold reservations
+            // on port 80; removing it eliminates the conflict everywhere without
+            // changing test behavior.
             .WithPortBinding( 11210, 11210 )
             .WithPortBinding( 8091, 8091 )
             .WithPortBinding( 8092, 8092 )

--- a/tests/Hyperbee.Migrations.Integration.Tests/Container/InitializeTestContainers.cs
+++ b/tests/Hyperbee.Migrations.Integration.Tests/Container/InitializeTestContainers.cs
@@ -1,4 +1,4 @@
-﻿using Hyperbee.Migrations.Integration.Tests.Container.Aerospike;
+using Hyperbee.Migrations.Integration.Tests.Container.Aerospike;
 using Hyperbee.Migrations.Integration.Tests.Container.Couchbase;
 using Hyperbee.Migrations.Integration.Tests.Container.MongoDb;
 using Hyperbee.Migrations.Integration.Tests.Container.OpenSearch;
@@ -9,6 +9,13 @@ namespace Hyperbee.Migrations.Integration.Tests.Container;
 [TestClass]
 public class InitializeTestContainers
 {
+    // Provider names recognized by HYPERBEE_TESTS_PROVIDERS_ONLY (case-insensitive).
+    private const string MongoDb = "MongoDb";
+    private const string Postgres = "Postgres";
+    private const string Couchbase = "Couchbase";
+    private const string Aerospike = "Aerospike";
+    private const string OpenSearch = "OpenSearch";
+
     [AssemblyInitialize]
     public static async Task Initialize( TestContext context )
     {
@@ -20,10 +27,43 @@ public class InitializeTestContainers
         if ( Environment.GetEnvironmentVariable( "HYPERBEE_TESTS_SKIP_SINGLE_NODE" ) == "true" )
             return;
 
-        await MongoDbTestContainer.Initialize( context );
-        await PostgresTestContainer.Initialize( context );
-        await CouchbaseTestContainer.Initialize( context );
-        await AerospikeTestContainer.Initialize( context );
-        await OpenSearchTestContainer.Initialize( context );
+        // HYPERBEE_TESTS_PROVIDERS_ONLY scopes the assembly initializer to a
+        // subset of providers. Without it, all five providers' containers
+        // start up — the historical default. With it, only the named
+        // providers (comma-separated, case-insensitive) initialize. Examples:
+        //
+        //   HYPERBEE_TESTS_PROVIDERS_ONLY=OpenSearch
+        //   HYPERBEE_TESTS_PROVIDERS_ONLY=Couchbase,MongoDb
+        //
+        // The motivation is that the assembly initializer is otherwise a
+        // single point of failure for the whole integration suite — any one
+        // provider's container failing to start (an environmental issue on
+        // a contributor's machine, a test-fixture timing problem, a flaky
+        // image pull) prevents EVERY test from running, including ones for
+        // unrelated providers. Provider scoping lets contributors verify
+        // changes affecting only their provider without fighting unrelated
+        // test-fixture problems.
+        var providers = ParseProviderFilter( Environment.GetEnvironmentVariable( "HYPERBEE_TESTS_PROVIDERS_ONLY" ) );
+
+        if ( providers is null || providers.Contains( MongoDb ) )
+            await MongoDbTestContainer.Initialize( context );
+        if ( providers is null || providers.Contains( Postgres ) )
+            await PostgresTestContainer.Initialize( context );
+        if ( providers is null || providers.Contains( Couchbase ) )
+            await CouchbaseTestContainer.Initialize( context );
+        if ( providers is null || providers.Contains( Aerospike ) )
+            await AerospikeTestContainer.Initialize( context );
+        if ( providers is null || providers.Contains( OpenSearch ) )
+            await OpenSearchTestContainer.Initialize( context );
+    }
+
+    private static HashSet<string>? ParseProviderFilter( string? raw )
+    {
+        if ( string.IsNullOrWhiteSpace( raw ) )
+            return null;
+
+        return raw
+            .Split( ',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries )
+            .ToHashSet( StringComparer.OrdinalIgnoreCase );
     }
 }

--- a/tests/Hyperbee.Migrations.Integration.Tests/OpenSearchR24cGapFillIntegrationTests.cs
+++ b/tests/Hyperbee.Migrations.Integration.Tests/OpenSearchR24cGapFillIntegrationTests.cs
@@ -248,13 +248,34 @@ public class OpenSearchR24cGapFillIntegrationTests
                 index, "1", PostData.String( """{ "id": "u1" }""" ) );
             Assert.IsTrue( ok.Success, $"mapped-only doc should index; got: {ok.Body}" );
 
-            // Indexing with an UNMAPPED field must be rejected by
-            // strict_dynamic_mapping.
-            var rejected = await ll.IndexAsync<StringResponse>(
-                index, "2", PostData.String( """{ "id": "u2", "unmapped_field": "x" }""" ) );
-            Assert.IsFalse( rejected.Success,
-                $"unmapped field should be rejected by dynamic:strict; got HTTP {rejected.HttpStatusCode}: {rejected.Body}" );
-            StringAssert.Contains( rejected.Body!, "strict_dynamic_mapping" );
+            // Indexing with an UNMAPPED field must be rejected by strict_dynamic_mapping.
+            // With ThrowExceptions=false the response captures the rejection; with
+            // ThrowExceptions=true (test-container default) the client throws instead.
+            StringResponse? rejected = null;
+            OpenSearchClientException? strictEx = null;
+            try
+            {
+                rejected = await ll.IndexAsync<StringResponse>(
+                    index, "2", PostData.String( """{ "id": "u2", "unmapped_field": "x" }""" ) );
+            }
+            catch ( OpenSearchClientException ex ) when ( ex.Response?.HttpStatusCode == 400 )
+            {
+                strictEx = ex;
+            }
+
+            if ( rejected != null )
+            {
+                Assert.IsFalse( rejected.Success,
+                    $"unmapped field should be rejected by dynamic:strict; got HTTP {rejected.HttpStatusCode}: {rejected.Body}" );
+                StringAssert.Contains( rejected.Body!, "strict_dynamic_mapping" );
+            }
+            else
+            {
+                Assert.IsNotNull( strictEx,
+                    "expected strict_dynamic_mapping rejection; got neither a failed response nor an exception" );
+                StringAssert.Contains( strictEx!.Message, "strict_dynamic_mapping",
+                    $"expected strict_dynamic_mapping in exception; got: {strictEx.Message}" );
+            }
         }
         finally
         {
@@ -538,8 +559,10 @@ public class OpenSearchR24cMultiNodeIntegrationTests
         finally
         {
             var ll = MultiNodeOpenSearchTestContainer.LowLevelClient;
-            await ll.Indices.DeleteAsync<StringResponse>( options.LedgerIndex );
-            await ll.Indices.DeleteAsync<StringResponse>( options.LockIndex );
+            // Best-effort cleanup — connection may fail if containers are torn down by a
+            // parallel framework's ClassCleanup before this finally block completes.
+            try { await ll.Indices.DeleteAsync<StringResponse>( options.LedgerIndex ); } catch ( Exception ) { }
+            try { await ll.Indices.DeleteAsync<StringResponse>( options.LockIndex ); } catch ( Exception ) { }
         }
     }
 }


### PR DESCRIPTION
## Summary
Two scope-distinct improvements bundled per the established release cadence (v2.2.1):

**Dispatcher / integration-test hardening** (commit `5563b5e`):
- `StatementDispatcher`: pass CAS query params (`if_seq_no`/`if_primary_term`) via `IRequestParameters` instead of embedding them in the path string (OpenSearch.Net rejects embedded query strings); add `CasPutParameters`.
- Handle `OpenSearchClientException` in `DispatchUpdateSettingsAsync` and `DispatchReindexAsync` for `ThrowExceptions=true` clients.
- `SafeDefaultMergeMiddleware`: co-inject `conflicts: proceed` with `op_type: create` on REINDEX to prevent abort-on-conflict defeating idempotency (ADR-0011).
- R-24c gap-fill tests: handle both `ThrowExceptions` modes; defensive cleanup against container-teardown races.
- `InitializeTestContainers`: `HYPERBEE_TESTS_PROVIDERS_ONLY` env gate to scope startup; `HYPERBEE_TESTS_SKIP_SINGLE_NODE` support.
- `CouchbaseTestContainer`: remove erroneous port 80 mapping.

**Public-surface gap closure** (commit `2528250`):
- `LedgerIndexInitStep` / `LockIndexInitStep`: tolerate the TOCTOU race between `Exists()` and `Create()` by detecting `resource_already_exists_exception` in both client modes. Ledger step still verifies the existing mapping on race-loss.
- `OpenSearchMigrationOptions`: full XML docs on every public type, enum value, property, const, and ctor; lift R-19 / R-29 / PA-2 rationale from line comments into `<summary>`/`<remarks>`; add `<see cref>` links between related options.
- `OpenSearchExceptions`: full XML docs on every exception type and ctor.

## Test plan
- [x] Provider builds clean: 0 warnings, 0 errors across net8/net9/net10.
- [x] Unit tests: 356/356 pass on net10.
- [x] Integration tests (non-MultiNode OpenSearch suite): 75/75 pass across all 3 frameworks.
- [ ] Multi-node OpenSearch tests: not run locally (Docker resource constraints — 3 JVMs); CI handles via R-28b `multi_node_tests.yml`.